### PR TITLE
RoundableLayout Open to Extension

### DIFF
--- a/library/src/main/java/com/tistory/zladnrms/roundablelayout/RoundableLayout.kt
+++ b/library/src/main/java/com/tistory/zladnrms/roundablelayout/RoundableLayout.kt
@@ -18,7 +18,7 @@ import androidx.annotation.ColorInt
 import java.lang.Exception
 
 
-class RoundableLayout : ConstraintLayout {
+open class RoundableLayout : ConstraintLayout {
 
     var path: Path? = null
 


### PR DESCRIPTION
If you are writing layouts in Kotlin (non-xml) it is very useful to be able to extend the RoundableLayout.